### PR TITLE
[Bugfix] Tile.get_elevation()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v1.0.2 -- 2022-06-09
+
+Bug Fix: incorrectly computing LatLon -> Tile Index conversion.
+  Caused `Tile.get_elevation` to give incorrect results for DTED
+  level 0 and 1 tiles.
+
 ## v1.0.1 -- 2021-11-15
 
 Bug Fix: incorrectly parsed dataset shape

--- a/dted/tile.py
+++ b/dted/tile.py
@@ -127,14 +127,9 @@ class Tile:
             )
 
         origin_latitude, origin_longitude = astuple(self.dsi.origin)
-        longitude_count, latitude_count = self.dsi.shape
-        lat_interval, lon_interval = self.dsi.latitude_interval, self.dsi.longitude_interval
-        latitude_index = round(
-            (latlon.latitude - origin_latitude) * (latitude_count - 1) / lat_interval
-        )
-        longitude_index = round(
-            (latlon.longitude - origin_longitude) * (longitude_count - 1) / lon_interval
-        )
+        lon_count, lat_count = self.dsi.shape
+        latitude_index = round((latlon.latitude - origin_latitude) * (lat_count - 1))
+        longitude_index = round((latlon.longitude - origin_longitude) * (lon_count - 1))
 
         if self._data is not None:
             return self._data[longitude_index, latitude_index]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dted"
-version = "1.0.1"
+version = "1.0.2"
 description = "Parser for DTED data."
 authors = ["Ben Bonenfant <bonenfan5ben@gmail.com>"]
 license = "MIT"

--- a/test/test_tile.py
+++ b/test/test_tile.py
@@ -79,6 +79,19 @@ def test_raw_file_parse(dted_file: Path) -> None:
 
 
 @pytest.mark.usefixtures("suppress_void_data_warning")
+def test_sanity_check_parsing(dted_file: Path) -> None:
+    """Perform a sanity check that elevation lookups are performed correctly
+    at the corners of the tile.
+    """
+    tile = Tile(dted_file, in_memory=True)
+
+    assert tile.get_elevation(tile.dsi.south_west_corner) == tile.data[0, 0]
+    assert tile.get_elevation(tile.dsi.north_west_corner) == tile.data[0, -1]
+    assert tile.get_elevation(tile.dsi.south_east_corner) == tile.data[-1, 0]
+    assert tile.get_elevation(tile.dsi.north_east_corner) == tile.data[-1, -1]
+
+
+@pytest.mark.usefixtures("suppress_void_data_warning")
 def test_data_shape(dted_file: Path) -> None:
     tile = Tile(dted_file, in_memory=True)
     assert tile.data.shape == tile.dsi.shape


### PR DESCRIPTION
The LatLon -> Tile Index conversion was performed incorrectly for DTED level 0 and 1 tiles.

Closes #6 